### PR TITLE
Add Filter\String::nullify()

### DIFF
--- a/src/Filter/String.php
+++ b/src/Filter/String.php
@@ -117,4 +117,26 @@ final class String
 
         throw new \Exception('$value was not filterable as a string');
     }
+
+    /**
+     * Method to filter empty or whitespace strings to null.
+     *
+     * @param string $value The starting value.
+     *
+     * @return null|string
+     *
+     * @throws \Exception Thrown if $value cannot be filtered.
+     */
+    public static function nullify($value)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_string($value)) {
+            throw new \Exception('$value was not filterable as a string');
+        }
+
+        return (trim($value) == '') ? null : $value;
+    }
 }

--- a/tests/Filter/StringTest.php
+++ b/tests/Filter/StringTest.php
@@ -298,4 +298,35 @@ final class StringUtilTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertSame('prefix' . __FILE__ . 'suffix', S::concat(new \SplFileInfo(__FILE__), false, 'prefix', 'suffix'));
     }
+
+    /**
+     * Verify basic behavior of nullify().
+     *
+     * @test
+     * @covers ::nullify
+     *
+     * @return void
+     */
+    public function nullify()
+    {
+        $this->assertNull(S::nullify(null));
+        $this->assertNull(S::nullify(''));
+        $this->assertNull(S::nullify("\n \t"));
+        $this->assertSame(" abc\n", S::nullify(" abc\n"));
+    }
+
+    /**
+     * Verify behavior of nullify() when $value is not a string.
+     *
+     * @test
+     * @covers ::nullify
+     * @expectedException \Exception
+     * @expectedExceptionMessage $value was not filterable as a string
+     *
+     * @return void
+     */
+    public function nullify_nonStringValue()
+    {
+        S::nullify(false);
+    }
 }


### PR DESCRIPTION
Will filter empty or whitespace strings to null. Useful when preparing data for DB storage.
